### PR TITLE
Implement skip_rows + column_names in R

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -48,14 +48,6 @@ library.
 
 ``` r
 library(arrow)
-#> 
-#> Attaching package: 'arrow'
-#> The following object is masked from 'package:utils':
-#> 
-#>     timestamp
-#> The following objects are masked from 'package:base':
-#> 
-#>     array, table
 set.seed(24)
 
 tab <- arrow::table(x = 1:10, y = rnorm(10))

--- a/r/man/csv_parse_options.Rd
+++ b/r/man/csv_parse_options.Rd
@@ -8,7 +8,7 @@
 csv_parse_options(delimiter = ",", quoting = TRUE,
   quote_char = "\\"", double_quote = TRUE, escaping = FALSE,
   escape_char = "\\\\", newlines_in_values = FALSE,
-  ignore_empty_lines = TRUE, header_rows = 1L)
+  ignore_empty_lines = TRUE)
 
 json_parse_options(newlines_in_values = FALSE)
 }
@@ -28,8 +28,6 @@ json_parse_options(newlines_in_values = FALSE)
 \item{newlines_in_values}{Whether values are allowed to contain CR (\code{0x0d}) and LF (\code{0x0a}) characters}
 
 \item{ignore_empty_lines}{Whether empty lines are ignored.  If \code{FALSE}, an empty line represents}
-
-\item{header_rows}{Number of header rows to skip (including the first row containing column names)}
 }
 \description{
 Parsing options for Arrow file readers

--- a/r/man/csv_read_options.Rd
+++ b/r/man/csv_read_options.Rd
@@ -6,14 +6,22 @@
 \title{Read options for the Arrow file readers}
 \usage{
 csv_read_options(use_threads = option_use_threads(),
-  block_size = 1048576L)
+  block_size = 1048576L, skip_rows = 0L, column_names = character(0))
 
 json_read_options(use_threads = TRUE, block_size = 1048576L)
 }
 \arguments{
 \item{use_threads}{Whether to use the global CPU thread pool}
 
-\item{block_size}{Block size we request from the IO layer; also determines the size of chunks when use_threads is \code{TRUE}. NB: if false, JSON input must end with an empty line}
+\item{block_size}{Block size we request from the IO layer; also determines
+the size of chunks when use_threads is \code{TRUE}. NB: if \code{FALSE}, JSON input
+must end with an empty line.}
+
+\item{skip_rows}{Number of lines to skip before reading data.}
+
+\item{column_names}{Character vector to supply column names. If length-0
+(the default), the first non-skipped row will be parsed to generate column
+names.}
 }
 \description{
 Read options for the Arrow file readers

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -7,22 +7,20 @@
 \title{Read a CSV or other delimited file with Arrow}
 \usage{
 read_delim_arrow(file, delim = ",", quote = "\\"",
-  escape_double = TRUE, escape_backslash = FALSE, col_select = NULL,
-  skip_empty_rows = TRUE, parse_options = NULL,
-  convert_options = NULL, read_options = csv_read_options(),
+  escape_double = TRUE, escape_backslash = FALSE, col_names = TRUE,
+  col_select = NULL, skip_empty_rows = TRUE, skip = 0L,
+  parse_options = NULL, convert_options = NULL, read_options = NULL,
   as_tibble = TRUE)
 
 read_csv_arrow(file, quote = "\\"", escape_double = TRUE,
-  escape_backslash = FALSE, col_select = NULL,
-  skip_empty_rows = TRUE, parse_options = NULL,
-  convert_options = NULL, read_options = csv_read_options(),
-  as_tibble = TRUE)
+  escape_backslash = FALSE, col_names = TRUE, col_select = NULL,
+  skip_empty_rows = TRUE, skip = 0L, parse_options = NULL,
+  convert_options = NULL, read_options = NULL, as_tibble = TRUE)
 
 read_tsv_arrow(file, quote = "\\"", escape_double = TRUE,
-  escape_backslash = FALSE, col_select = NULL,
-  skip_empty_rows = TRUE, parse_options = NULL,
-  convert_options = NULL, read_options = csv_read_options(),
-  as_tibble = TRUE)
+  escape_backslash = FALSE, col_names = TRUE, col_select = NULL,
+  skip_empty_rows = TRUE, skip = 0L, parse_options = NULL,
+  convert_options = NULL, read_options = NULL, as_tibble = TRUE)
 }
 \arguments{
 \item{file}{A character path to a local file, or an Arrow input stream}
@@ -40,12 +38,19 @@ characters? This is more general than \code{escape_double} as backslashes
 can be used to escape the delimiter character, the quote character, or
 to add special characters like \code{\\n}.}
 
+\item{col_names}{If \code{TRUE}, the first row of the input will be used as the
+column names and will not be included in the data frame. (Note that \code{FALSE}
+is not currently supported.) Alternatively, you can specify a character
+vector of column names.}
+
 \item{col_select}{A \link[tidyselect:vars_select]{tidy selection specification}
 of columns, as used in \code{dplyr::select()}.}
 
 \item{skip_empty_rows}{Should blank rows be ignored altogether? If
 \code{TRUE}, blank rows will not be represented at all. If \code{FALSE}, they will be
 filled with missings.}
+
+\item{skip}{Number of lines to skip before reading data.}
 
 \item{parse_options}{see \code{\link[=csv_parse_options]{csv_parse_options()}}. If given, this overrides any
 parsing options provided in other arguments (e.g. \code{delim}, \code{quote}, etc.).}

--- a/r/src/csv.cpp
+++ b/r/src/csv.cpp
@@ -28,6 +28,8 @@ std::shared_ptr<arrow::csv::ReadOptions> csv___ReadOptions__initialize(List_ opt
       std::make_shared<arrow::csv::ReadOptions>(arrow::csv::ReadOptions::Defaults());
   res->use_threads = options["use_threads"];
   res->block_size = options["block_size"];
+  res->skip_rows = options["skip_rows"];
+  // res->column_names = options["column_names"];
   return res;
 }
 
@@ -43,7 +45,6 @@ std::shared_ptr<arrow::csv::ParseOptions> csv___ParseOptions__initialize(List_ o
   res->double_quote = options["double_quote"];
   res->escape_char = get_char(options["escape_char"]);
   res->newlines_in_values = options["newlines_in_values"];
-  res->header_rows = options["header_rows"];
   res->ignore_empty_lines = options["ignore_empty_lines"];
   return res;
 }

--- a/r/src/csv.cpp
+++ b/r/src/csv.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<arrow::csv::ReadOptions> csv___ReadOptions__initialize(List_ opt
   res->use_threads = options["use_threads"];
   res->block_size = options["block_size"];
   res->skip_rows = options["skip_rows"];
-  // res->column_names = options["column_names"];
+  res->column_names = Rcpp::as<std::vector<std::string>>(options["column_names"]);
   return res;
 }
 

--- a/r/tests/testthat/test-arrow-csv.R
+++ b/r/tests/testthat/test-arrow-csv.R
@@ -94,7 +94,6 @@ test_that("read_csv_arrow parsing options: col_names", {
 })
 
 test_that("read_csv_arrow parsing options: skip", {
-  skip("Invalid: Empty CSV file")
   tf <- tempfile()
   on.exit(unlink(tf))
 

--- a/r/tests/testthat/test-arrow-csv.R
+++ b/r/tests/testthat/test-arrow-csv.R
@@ -81,28 +81,39 @@ test_that("read_delim_arrow parsing options: quote", {
 })
 
 test_that("read_csv_arrow parsing options: col_names", {
-  skip("Invalid: Empty CSV file")
   tf <- tempfile()
   on.exit(unlink(tf))
 
+  # Writing the CSV without the header
   write.table(iris, tf, sep = ",", row.names = FALSE, col.names = FALSE)
-  tab1 <- read_csv_arrow(tf, col_names = FALSE)
+
+  expect_error(read_csv_arrow(tf, col_names = FALSE), "Not implemented")
+
+  tab1 <- read_csv_arrow(tf, col_names = names(iris))
 
   expect_identical(names(tab1), names(iris))
   iris$Species <- as.character(iris$Species)
   expect_equivalent(iris, tab1)
+
+  # This errors (correctly) because I haven't given enough names
+  # but the error message is "Invalid: Empty CSV file", which is not accurate
+  expect_error(
+    read_csv_arrow(tf, col_names = names(iris)[1])
+  )
+  # Same here
+  expect_error(
+    read_csv_arrow(tf, col_names = c(names(iris), names(iris)))
+  )
 })
 
 test_that("read_csv_arrow parsing options: skip", {
   tf <- tempfile()
   on.exit(unlink(tf))
 
+  # Adding two garbage lines to start the csv
   cat("asdf\nqwer\n", file = tf)
   suppressWarnings(write.table(iris, tf, sep = ",", row.names = FALSE, append = TRUE))
-  # This works:
-  # print(head(readr::read_csv(tf, skip = 2)))
 
-  # This errors:
   tab1 <- read_csv_arrow(tf, skip = 2)
 
   expect_identical(names(tab1), names(iris))


### PR DESCRIPTION
The new behavior is working as expected now. Two other observations:

1. The error message(s) are not great when you give bad input. For example, if I give too many or too few column_names, the error I get is `Invalid: Empty CSV file`, same as what I was getting before your latest change to the skip_rows behavior. It would be nice if the error message were accurate, and even better if it were more specific so that I as a user might know how to fix my bad input.
2. On a related note, if `ignore_empty_lines` is false and there are empty lines, it fails to parse (again, with `Invalid: Empty CSV file`).

Happy to take those up in a separate ticket if you prefer, just observed them while working on this.