### PR TITLE
ARROW-13480: Extended scanner tests to regress issue.

### DIFF
--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -544,7 +544,10 @@ class FailingScanTaskFragment : public InMemoryFragment {
   using InMemoryFragment::InMemoryFragment;
   Result<ScanTaskIterator> Scan(std::shared_ptr<ScanOptions> options) override {
     auto self = shared_from_this();
-    ScanTaskVector scan_tasks{std::make_shared<T>(record_batches_, options, self)};
+    ScanTaskVector scan_tasks;
+    for (int i = 0; i < 4; i++) {
+      scan_tasks.push_back(std::make_shared<T>(record_batches_, options, self));
+    }
     return MakeVectorIterator(std::move(scan_tasks));
   }
 


### PR DESCRIPTION
The existing tests were only generating one scan task and, as you noted, it takes multiple to trigger the deadlock.  I confirmed this modification to the test deadlocks on master.